### PR TITLE
from global variables to es6 import

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1,7 +1,10 @@
 import User from './components/User.js';
 import AppHomeRoute from './routes/AppHomeRoute';
+import ReactDOM from 'react-dom';
+import Relay from 'react-relay';
+import React from 'react';
 
-let userId = getQueryParams(document.location.search).user || "55fd15c66acff8260e56d341";
+let userId = getQueryParams(document.location.search).user || "56731a3dfb084e5849ee40fe";
 
 ReactDOM.render(
   <Relay.RootContainer

--- a/js/components/AddHobby.js
+++ b/js/components/AddHobby.js
@@ -1,3 +1,5 @@
+import Relay from 'react-relay';
+import React from 'react';
 class AddHobby extends React.Component {
   constructor(props) {
     super(props);

--- a/js/components/Age.js
+++ b/js/components/Age.js
@@ -1,4 +1,6 @@
+import Relay from 'react-relay';
 import AgeMutation from './AgeMutation.js';
+import React from 'react';
 
 class Age extends React.Component {
 

--- a/js/components/AgeMutation.js
+++ b/js/components/AgeMutation.js
@@ -1,3 +1,4 @@
+import Relay from 'react-relay';
 export default class AgeMutation extends Relay.Mutation {
   static fragments = {
     user: () => Relay.QL`

--- a/js/components/Friend.js
+++ b/js/components/Friend.js
@@ -1,3 +1,5 @@
+import Relay from 'react-relay';
+import React from 'react';
 class Friend extends React.Component {
   render() {
     let friend = this.props.friend;

--- a/js/components/FriendsList.js
+++ b/js/components/FriendsList.js
@@ -1,4 +1,6 @@
+import Relay from 'react-relay';
 import Friend from './Friend.js';
+import React from 'react';
 
 class FriendList extends React.Component {
   render() {

--- a/js/components/Hobby.js
+++ b/js/components/Hobby.js
@@ -1,3 +1,5 @@
+import Relay from 'react-relay';
+import React from 'react';
 class Hobby extends React.Component {
   render() {
     let hobby = this.props.hobby;

--- a/js/components/HobbyList.js
+++ b/js/components/HobbyList.js
@@ -1,3 +1,5 @@
+import Relay from 'react-relay';
+import React from 'react';
 import Hobby from './Hobby.js';
 
 class HobbyList extends React.Component {

--- a/js/components/User.js
+++ b/js/components/User.js
@@ -1,3 +1,5 @@
+import Relay from 'react-relay';
+import React from 'react';
 import HobbyList from './HobbyList.js';
 import FriendsList from './FriendsList.js';
 import {Age} from './Age.js';

--- a/js/routes/AppHomeRoute.js
+++ b/js/routes/AppHomeRoute.js
@@ -1,3 +1,4 @@
+import Relay from 'react-relay';
 class AppHomeRoute extends Relay.Route {
   static queries = {
     user: (Component) => Relay.QL `

--- a/public/index.html
+++ b/public/index.html
@@ -7,25 +7,7 @@
 </head>
 <body>
 <div id="root"></div>
-<script type="text/javascript">
-    // Force `fetch` polyfill to workaround Chrome not displaying request body
-    // in developer tools for the native `fetch`.
-    self.fetch = null;
-    function warnRelayMissing() {
-        document.body.innerHTML = (
-        '<h2>Could not find relay.js</h2>' +
-        '<p>' +
-        'Be sure to run <code>npm run build</code> ' +
-        'in the <code>relay/</code> directory.' +
-        '</p>'
-        );
-    }
-</script>
 <script src="http://localhost:3000/webpack-dev-server.js"></script>
-<script src="node_modules/react/dist/react.min.js"></script>
-<script src="node_modules/react/dist/react-dom.min.js"></script>
-<script src="node_modules/react-relay/dist/relay.js"
-        onerror="warnRelayMissing()"></script>
 <script src="js/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
I've removed all the `<script>` tags in favor of es6 import. It solves all the problems with 'Relay is undefined' etc.
