### PR TITLE
Get rid of babel-node-debug

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,5 @@
     "react-dom": "^0.14.0-rc",
     "react-relay": "^0.3.1",
     "mongoose": "~4.1.7"
-  },
-  "devDependencies": {
-    "babel-node-debug": "~1.1.0"
   }
 }


### PR DESCRIPTION
Babel-node-debug is not supported and causes error with npm install at 7.8+ node with npm 4.2+. It fails with trying to install v8-debug@0.7.7.